### PR TITLE
fix: remove deprecated baseUrl from tsconfig for TypeScript 6 compatibility

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,7 +21,6 @@
     "noImplicitAny": false,
     "noFallthroughCasesInSwitch": false,
 
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     { "path": "./tsconfig.node.json" }
   ],
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
## 📋 TypeScript 6.0 Compatibility Fix

### Problem

TypeScript 6.0 deprecated the `baseUrl` compiler option. This was flagged in the `dev-major-29cc72427c` branch and needs to be applied to main after the TypeScript 6 upgrade from PR #28.

### Changes

| File | Change |
|------|--------|
| `tsconfig.json` | Removed deprecated `baseUrl: "."` |
| `tsconfig.app.json` | Removed deprecated `baseUrl: "."` |

### Why This Is Safe

- Path aliases (`@/*` → `./src/*`) are handled by **Vite's `resolve.alias`** configuration, not by TypeScript's `baseUrl`
- TypeScript 6.0+ still resolves `paths` correctly without `baseUrl` when using project references
- This eliminates deprecation warnings and future-proofs the config

### Related

- Follows up on PR #28 (TypeScript 5.9.3 → 6.0.2 upgrade)
- Cherry-picked from the `dev-major-29cc72427c` branch