### PR TITLE
security: fix critical axios SSRF vulnerability and code quality issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@tanstack/react-query": "^5.95.2",
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
-        "axios": "^1.14.0",
+        "axios": "^1.15.0",
         "browser-image-compression": "^2.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -6617,9 +6617,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@tanstack/react-query": "^5.95.2",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
-    "axios": "^1.14.0",
+    "axios": "^1.15.0",
     "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/components/admin/EscalationPolicyConfig.tsx
+++ b/src/components/admin/EscalationPolicyConfig.tsx
@@ -8,8 +8,6 @@ import React, { useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import {


### PR DESCRIPTION
## Summary

- **[CRITICAL]** Update axios from 1.14.0 to 1.15.0 to patch CVE-2025-62718 (NO_PROXY hostname normalization bypass leading to SSRF)
- Remove unused imports (`Input`, `Label`) in `EscalationPolicyConfig.tsx`

## Security Fixes

### Dependabot Alert #123 — CVE-2025-62718 (Critical, CVSS 9.3)
Axios does not correctly handle hostname normalization when checking `NO_PROXY` rules. Requests to loopback addresses like `localhost.` (with trailing dot) or `[::1]` (IPv6 literal) skip `NO_PROXY` matching and go through the configured proxy, enabling SSRF attacks.

**Fix:** Update `axios` from `1.14.0` → `1.15.0` (first patched version)

### Code Scanning Alerts #11107, #11108
Unused imports `Input` and `Label` in `EscalationPolicyConfig.tsx` (lines 11-12).

**Fix:** Remove the unused import statements.

## Test Plan

- [x] Build succeeds (`npm run build`)
- [x] Existing tests pass (20/20 test cases pass)
- [x] No new lint errors introduced
- [x] Verified axios is not used with NO_PROXY in this codebase
- [ ] Dependabot alert #123 auto-closes after merge
- [ ] Code Scanning alerts #11107, #11108 auto-close after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated axios dependency to latest minor version for improved stability.
  * Removed unused code imports to reduce bundle size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->