### PR TITLE
fix(auth): resolve handle_new_user trigger blocking signup

### DIFF
--- a/src/components/team/enhanced/CollaborationMetricsChart.tsx
+++ b/src/components/team/enhanced/CollaborationMetricsChart.tsx
@@ -120,7 +120,7 @@ export function CollaborationMetricsChart({
               {memberAnalytics.filter(m => m.collaboration_score > 70).length}
             </div>
             <p className="text-xs text-muted-foreground">
-              Score > 70
+              Score &gt; 70
             </p>
           </CardContent>
         </Card>

--- a/supabase/migrations/20260515130000_fix_handle_new_user_google_avatar_scope.sql
+++ b/supabase/migrations/20260515130000_fix_handle_new_user_google_avatar_scope.sql
@@ -1,0 +1,49 @@
+-- Fix scoping bug in handle_new_user(): google_avatar was declared inside a
+-- nested DECLARE/BEGIN…END block that closed before the INSERT, so Postgres
+-- treated google_avatar in the VALUES clause as a column reference, raising
+-- `column "google_avatar" does not exist` and aborting every new-user insert
+-- (Google OAuth + email signup) with a 500 at /callback.
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+DECLARE
+  google_avatar TEXT := NULL;
+BEGIN
+  IF new.raw_user_meta_data IS NOT NULL THEN
+    google_avatar := new.raw_user_meta_data->>'avatar_url';
+  END IF;
+
+  INSERT INTO public.profiles (
+    id,
+    first_name,
+    last_name,
+    email,
+    google_avatar_url,
+    subscription_tier,
+    subscription_status,
+    receipts_used_this_month,
+    monthly_reset_date
+  )
+  VALUES (
+    new.id,
+    COALESCE(new.raw_user_meta_data->>'given_name', ''),
+    COALESCE(new.raw_user_meta_data->>'family_name', ''),
+    new.email,
+    google_avatar,
+    'free',
+    'active',
+    0,
+    DATE_TRUNC('month', NOW()) + INTERVAL '1 month'
+  )
+  ON CONFLICT (id) DO UPDATE SET
+    email = EXCLUDED.email,
+    google_avatar_url = COALESCE(EXCLUDED.google_avatar_url, profiles.google_avatar_url),
+    first_name = COALESCE(NULLIF(EXCLUDED.first_name, ''), profiles.first_name),
+    last_name = COALESCE(NULLIF(EXCLUDED.last_name, ''), profiles.last_name),
+    updated_at = NOW();
+
+  RETURN new;
+END;
+$function$;


### PR DESCRIPTION
## Summary
- Fixes Google OAuth and email signups failing with `500: Database error saving new user` at `/callback`
- Root cause: `public.handle_new_user()` declared `google_avatar` inside a nested `DECLARE/BEGIN…END` block that closed before the `INSERT`, so Postgres treated `google_avatar` in `VALUES` as a column reference (`column "google_avatar" does not exist`, SQLSTATE 42703) and aborted every new-user insert. Existing users were unaffected.
- Hoists the `DECLARE` to the function's top-level block so the variable stays in scope through the `INSERT`.
- Also fixes an unrelated TS1382 in `CollaborationMetricsChart.tsx` by escaping a literal `>` in JSX text.

## Notes
- Migration was already applied directly to production (`mpmkbtsufihzdelrlszs`) to unblock signups; this PR adds the matching migration file so the repo and remote are in sync.
- No schema changes — only a `CREATE OR REPLACE FUNCTION`.
- Reversible: the previous broken definition can be restored from git history if needed.

## Test plan
- [ ] Sign in with a fresh Google account → `/callback` returns 302, profile row is created
- [ ] Sign up with a new email + password → confirmation email sent, profile row created on first sign-in
- [ ] Existing user sign-in still works (regression check)
- [ ] Verify Supabase auth logs no longer contain `column "google_avatar" does not exist`
- [ ] `npx tsc --noEmit -p tsconfig.app.json` no longer reports TS1382 for `CollaborationMetricsChart.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)