### PR TITLE
fix(team-invitations): deliver invite emails and notify invitees in-app

### DIFF
--- a/src/services/teamService.ts
+++ b/src/services/teamService.ts
@@ -128,7 +128,76 @@ export class TeamService {
       // Don't throw here - the invitation was created successfully
     }
 
+    // Create an in-app notification for the invitee if they already have an account.
+    // This lets them accept directly from the notification bell at /invite/{token}.
+    try {
+      await this.createInviteeInAppNotification(invitationId, request);
+    } catch (notifyError) {
+      console.error('Failed to create in-app invitation notification:', notifyError);
+      // Non-fatal — invite still works via email or shared link
+    }
+
     return invitationId;
+  }
+
+  private async createInviteeInAppNotification(
+    invitationId: string,
+    request: InviteTeamMemberRequest,
+  ): Promise<void> {
+    const { data: invitation, error: invitationError } = await supabase
+      .from('team_invitations')
+      .select('id, token, email, team_id, role, expires_at, teams!team_id(name)')
+      .eq('id', invitationId)
+      .single();
+
+    if (invitationError || !invitation) {
+      console.warn('Skipping invitee notification — invitation not retrievable:', invitationError);
+      return;
+    }
+
+    const { data: invitee, error: inviteeError } = await supabase
+      .from('profiles')
+      .select('id, first_name, last_name')
+      .eq('email', invitation.email)
+      .maybeSingle();
+
+    if (inviteeError) {
+      console.warn('Skipping invitee notification — profile lookup failed:', inviteeError);
+      return;
+    }
+
+    if (!invitee?.id) {
+      // Invitee has no Mataresit account yet — they'll get the email instead
+      return;
+    }
+
+    const teamName = (invitation.teams as { name?: string } | null)?.name || 'a team';
+    const inviteeFirstName = invitee.first_name?.trim();
+
+    const { error: notificationError } = await supabase.from('notifications').insert({
+      recipient_id: invitee.id,
+      team_id: invitation.team_id,
+      type: 'team_invitation_sent',
+      priority: 'high',
+      title: `You're invited to join ${teamName}`,
+      message: inviteeFirstName
+        ? `${inviteeFirstName}, you've been invited to join ${teamName} as ${invitation.role}. Click to accept.`
+        : `You've been invited to join ${teamName} as ${invitation.role}. Click to accept.`,
+      action_url: `/invite/${invitation.token}`,
+      related_entity_type: 'team_invitation',
+      related_entity_id: invitation.id,
+      expires_at: invitation.expires_at,
+      metadata: {
+        invitation_id: invitation.id,
+        team_id: invitation.team_id,
+        role: invitation.role,
+        token: invitation.token,
+      },
+    });
+
+    if (notificationError) {
+      console.warn('Failed to insert invitee notification:', notificationError);
+    }
   }
 
   async acceptInvitation(token: string): Promise<boolean> {

--- a/supabase/functions/send-team-invitation-email/index.ts
+++ b/supabase/functions/send-team-invitation-email/index.ts
@@ -110,6 +110,10 @@ serve(async (req) => {
     }
 
     let providerMessageId: string | undefined;
+    const timeoutMsRaw = Number(Deno.env.get('RESEND_REQUEST_TIMEOUT_MS') ?? '8000');
+    const resendTimeoutMs = Number.isFinite(timeoutMsRaw) && timeoutMsRaw > 0 ? timeoutMsRaw : 8000;
+    const controller = new AbortController();
+    const timeoutHandle = setTimeout(() => controller.abort(), resendTimeoutMs);
     try {
       const response = await fetch('https://api.resend.com/emails', {
         method: 'POST',
@@ -124,6 +128,7 @@ serve(async (req) => {
           html,
           text,
         }),
+        signal: controller.signal,
       });
 
       if (!response.ok) {
@@ -150,22 +155,39 @@ serve(async (req) => {
         provider_message_id: providerMessageId,
       });
     } catch (sendError) {
-      console.error('Error sending invitation email via Resend:', sendError);
+      const isTimeout =
+        (sendError as { name?: string }).name === 'AbortError' ||
+        controller.signal.aborted;
+      const errorMessage = isTimeout
+        ? `Resend request timed out after ${resendTimeoutMs}ms`
+        : (sendError as Error).message;
+      console.error('Error sending invitation email via Resend:', {
+        timeout: isTimeout,
+        message: errorMessage,
+      });
       if (deliveryId) {
         await supabaseClient.rpc('update_email_delivery_status', {
           _delivery_id: deliveryId,
           _status: 'failed',
           _provider_message_id: null,
-          _error_message: (sendError as Error).message,
+          _error_message: errorMessage,
         });
       }
       return new Response(
         JSON.stringify({
-          error: 'Failed to send invitation email',
-          details: (sendError as Error).message,
+          error: isTimeout
+            ? 'Invitation email send timed out'
+            : 'Failed to send invitation email',
+          details: errorMessage,
+          timeout: isTimeout,
         }),
-        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        {
+          status: isTimeout ? 504 : 500,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        }
       );
+    } finally {
+      clearTimeout(timeoutHandle);
     }
 
     return new Response(

--- a/supabase/functions/send-team-invitation-email/index.ts
+++ b/supabase/functions/send-team-invitation-email/index.ts
@@ -7,7 +7,6 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-// Initialize Supabase client
 const supabaseClient = createClient(
   Deno.env.get('SUPABASE_URL') ?? '',
   Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
@@ -24,47 +23,36 @@ serve(async (req) => {
     if (!invitation_id) {
       return new Response(
         JSON.stringify({ error: 'Missing invitation_id' }),
-        {
-          status: 400,
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
-        }
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
-    // Get invitation details with team and inviter information
     const { data: invitation, error: invitationError } = await supabaseClient
       .from('team_invitations')
-      .select(`
-        *,
-        teams!team_id(name)
-      `)
+      .select(`*, teams!team_id(name)`)
       .eq('id', invitation_id)
       .single();
 
     if (invitationError || !invitation) {
       console.error('Error fetching invitation:', invitationError);
       return new Response(
-        JSON.stringify({ error: 'Invitation not found' }),
-        {
-          status: 404,
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
-        }
+        JSON.stringify({ error: 'Invitation not found', details: invitationError }),
+        { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
-    // Get inviter information separately including language preference
     const { data: inviterProfile } = await supabaseClient
       .from('profiles')
       .select('first_name, last_name, email, preferred_language')
       .eq('id', invitation.invited_by)
       .single();
 
-    // Prepare email data
     const inviterName = inviterProfile?.first_name
       ? `${inviterProfile.first_name} ${inviterProfile.last_name || ''}`.trim()
       : inviterProfile?.email || 'Someone';
 
-    const acceptUrl = `${Deno.env.get('SITE_URL') || 'http://localhost:3000'}/invite/${invitation.token}`;
+    const siteUrl = Deno.env.get('SITE_URL') || 'https://mataresit.co';
+    const acceptUrl = `${siteUrl}/invite/${invitation.token}`;
 
     const emailData = {
       inviteeEmail: invitation.email,
@@ -73,76 +61,133 @@ serve(async (req) => {
       role: invitation.role,
       acceptUrl,
       expiresAt: invitation.expires_at,
-      language: inviterProfile?.preferred_language || 'en', // Use inviter's language preference
+      language: inviterProfile?.preferred_language || 'en',
     };
 
-    // Generate email content
     const { subject, html, text } = generateTeamInvitationEmail(emailData);
 
-    // Send email using the send-email function
-    const emailResponse = await supabaseClient.functions.invoke('send-email', {
-      body: {
-        to: invitation.email,
-        subject,
-        html,
-        text,
-        template_name: 'team_invitation',
-        related_entity_type: 'team_invitation',
-        related_entity_id: invitation_id,
-        team_id: invitation.team_id,
-        metadata: {
-          invitation_id,
-          team_name: invitation.teams?.name,
-          role: invitation.role,
-          inviter_email: inviterProfile?.email,
-        },
+    // Track delivery via existing RPC (matches send-email behavior)
+    let deliveryId: string | undefined;
+    const { data: deliveryData, error: deliveryError } = await supabaseClient.rpc('create_email_delivery', {
+      _recipient_email: invitation.email,
+      _subject: subject,
+      _template_name: 'team_invitation',
+      _related_entity_type: 'team_invitation',
+      _related_entity_id: invitation_id,
+      _team_id: invitation.team_id,
+      _metadata: {
+        invitation_id,
+        team_name: invitation.teams?.name,
+        role: invitation.role,
+        inviter_email: inviterProfile?.email,
       },
     });
 
-    if (emailResponse.error) {
-      console.error('Error sending invitation email:', emailResponse.error);
+    if (deliveryError) {
+      console.error('Error creating email delivery record:', deliveryError);
+    } else {
+      deliveryId = deliveryData as string;
+    }
+
+    const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY');
+    const FROM_EMAIL = Deno.env.get('FROM_EMAIL') || 'Mataresit <noreply@mataresit.co>';
+
+    if (!RESEND_API_KEY) {
+      const errorMessage = 'RESEND_API_KEY is not configured';
+      console.error(errorMessage);
+      if (deliveryId) {
+        await supabaseClient.rpc('update_email_delivery_status', {
+          _delivery_id: deliveryId,
+          _status: 'failed',
+          _provider_message_id: null,
+          _error_message: errorMessage,
+        });
+      }
       return new Response(
-        JSON.stringify({ 
-          error: 'Failed to send invitation email',
-          details: emailResponse.error 
-        }),
-        {
-          status: 500,
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
-        }
+        JSON.stringify({ error: errorMessage }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
-    console.log('Team invitation email sent successfully:', {
-      invitation_id,
-      recipient: invitation.email,
-      team: invitation.teams?.name,
-    });
+    let providerMessageId: string | undefined;
+    try {
+      const response = await fetch('https://api.resend.com/emails', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${RESEND_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          from: FROM_EMAIL,
+          to: [invitation.email],
+          subject,
+          html,
+          text,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Resend API error (${response.status}): ${errorText}`);
+      }
+
+      const result = await response.json();
+      providerMessageId = result.id;
+
+      if (deliveryId) {
+        await supabaseClient.rpc('update_email_delivery_status', {
+          _delivery_id: deliveryId,
+          _status: 'sent',
+          _provider_message_id: providerMessageId,
+          _error_message: null,
+        });
+      }
+
+      console.log('Team invitation email sent successfully:', {
+        invitation_id,
+        recipient: invitation.email,
+        team: invitation.teams?.name,
+        provider_message_id: providerMessageId,
+      });
+    } catch (sendError) {
+      console.error('Error sending invitation email via Resend:', sendError);
+      if (deliveryId) {
+        await supabaseClient.rpc('update_email_delivery_status', {
+          _delivery_id: deliveryId,
+          _status: 'failed',
+          _provider_message_id: null,
+          _error_message: (sendError as Error).message,
+        });
+      }
+      return new Response(
+        JSON.stringify({
+          error: 'Failed to send invitation email',
+          details: (sendError as Error).message,
+        }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
 
     return new Response(
-      JSON.stringify({ 
+      JSON.stringify({
         success: true,
         message: 'Team invitation email sent successfully',
         invitation_id,
         recipient: invitation.email,
+        delivery_id: deliveryId,
+        provider_message_id: providerMessageId,
       }),
-      {
-        status: 200,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
-      }
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
 
   } catch (error) {
     console.error('Error in send-team-invitation-email function:', error);
     return new Response(
-      JSON.stringify({ 
-        error: error.message,
-        timestamp: new Date().toISOString()
+      JSON.stringify({
+        error: (error as Error).message,
+        timestamp: new Date().toISOString(),
       }),
-      {
-        status: 500,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
-      }
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 });


### PR DESCRIPTION
## Summary
- Fix invitation **emails never being delivered**. Production edge-function logs showed `send-team-invitation-email` → 500, with its inner call to `send-email` returning 401 Unauthorized — `supabase.functions.invoke()` between two functions didn't carry valid auth, so JWT verification rejected it and Resend was never called. `send-team-invitation-email` now calls the Resend API directly using the existing `RESEND_API_KEY` / `FROM_EMAIL` secrets, and records delivery via the existing `create_email_delivery` / `update_email_delivery_status` RPCs.
- Fix **in-app accept-from-bell**. Previously only team admins received a `team_invitation_sent` notification, pointing to `/teams/{id}/members`. The actual invitee never got one. After `invite_team_member` succeeds, `teamService.inviteTeamMember` now looks up the invitee in `profiles` by email and, if they have a Mataresit account, inserts a high-priority `team_invitation_sent` notification with `action_url=/invite/{token}`. `NotificationCenter` already navigates to `action_url`, so clicking the bell goes straight to the accept flow. Users without an account still get the invite email.
- No schema migrations, no signature changes; existing RLS already permits notification inserts.

## Test plan
- [ ] Edge function deployed (already deployed to `mpmkbtsufihzdelrlszs` as part of this fix). Inspect [Functions → send-team-invitation-email](https://supabase.com/dashboard/project/mpmkbtsufihzdelrlszs/functions) and confirm new version is active.
- [ ] Send a fresh invite to a brand-new email address — confirm the recipient gets the Resend-delivered invitation in their inbox.
- [ ] Send an invite to an email that **already** has a Mataresit account — confirm the bell badge increments for that user, the notification reads `You're invited to join {team}`, and clicking it lands on `/invite/{token}` and accepts cleanly.
- [ ] Send an invite to an email **without** a Mataresit account — confirm only the email is sent (no orphan notification, no error in `teamService` logs).
- [ ] Check the `email_deliveries` table — the row for the new invite should be `status='sent'` with a `provider_message_id` set.
- [ ] Verify Supabase logs for `send-team-invitation-email` show 200, not 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invitees now receive in-app notifications with a direct link to accept team invitations.
  * Invitation emails use the inviter’s preferred language and include delivery tracking info.

* **Bug Fixes / Reliability**
  * Email delivery now reports success/failure and handles timeouts; failed sends are marked so invites remain consistent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noa10/mataresit/pull/76)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->