### PR TITLE
fix(notifications): resolve duplicate subscribe error and mark-all-read scope mismatch

### DIFF
--- a/src/contexts/NotificationContext.tsx
+++ b/src/contexts/NotificationContext.tsx
@@ -702,8 +702,12 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
     broadcastToOtherTabs('mark_all_read');
 
     try {
-      // Perform backend operation
-      const count = await notificationService.markAllNotificationsAsRead(currentTeam?.id);
+      // Perform backend operation.
+      // NOTE: getUserNotifications returns notifications across all teams (not scoped),
+      // so the "mark all" RPC must also be unscoped. Passing currentTeam.id would only
+      // mark the current team's notifications, leaving others unread in the DB — they
+      // repopulate the unread count on the next refetch (focus, reconnect, team switch).
+      const count = await notificationService.markAllNotificationsAsRead();
 
       const duration = performance.now() - startTime;
       console.log(`✅ Mark all as read operation completed in ${duration.toFixed(2)}ms`);

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -793,6 +793,15 @@ export class NotificationService {
 
     this.pendingSubscriptions.add(channelName);
 
+    // 🔧 FIX: Flush any pending deferred channel removals before creating a new
+    // channel with the same name. Without this, supabase.channel(channelName) can
+    // return the previously-subscribed channel (still alive because removal was
+    // queued for the next tick), and `.on('postgres_changes', …)` on a SUBSCRIBED
+    // channel throws: "cannot add `postgres_changes` callbacks ... after subscribe()".
+    if (this.deferredCleanupQueue.has(channelName)) {
+      this.processDeferredCleanup();
+    }
+
     // OPTIMIZATION: Build selective event filter instead of using '*'
     const events = options?.events || ['INSERT', 'UPDATE', 'DELETE'];
     const eventFilter = events.length === 3 ? '*' : events.join(',');
@@ -1088,6 +1097,9 @@ export class NotificationService {
   private processDeferredCleanup(): void {
     const channelsToCleanup = Array.from(this.deferredCleanupQueue);
     this.deferredCleanupQueue.clear();
+    if (this.cleanupBatchTimer) {
+      clearTimeout(this.cleanupBatchTimer);
+    }
     this.cleanupBatchTimer = null;
 
     for (const channelName of channelsToCleanup) {


### PR DESCRIPTION
## Summary
- Fix `Failed to setup real-time subscriptions: Error: cannot add postgres_changes callbacks for realtime:user-changes-<id> after subscribe()` thrown when the notification effect re-runs (StrictMode mount, team switch, hot reload).
- Fix "Mark all as read" reverting after a few minutes — count went back up on the next refetch.

## Bug 1 — duplicate subscribe error
`cleanupSubscription` queued channel removal via `setTimeout(0)` but synchronously deleted the registry entry. When the effect re-ran, `subscribeToAllUserNotificationChanges` saw no active subscription and called `supabase.channel(name)` — Supabase returned the still-alive previous channel, already in SUBSCRIBED state, and `.on('postgres_changes', ...)` threw.

Fix: flush `deferredCleanupQueue` synchronously when re-subscribing to a channel whose name is still pending removal, and clear the dangling `cleanupBatchTimer` in `processDeferredCleanup` so manual flushes don't leave a no-op timer queued. (`src/services/notificationService.ts`)

## Bug 2 — mark all as read scope mismatch
`markAllAsRead` passed `currentTeam?.id` to the RPC, which scopes the UPDATE to a single team. But `getUserNotifications` returns notifications across all teams (the `team_id` filter built in `NotificationContext` is dead — never reaches the RPC). Personal / other-team notifications stayed unread in the DB and repopulated on the next refetch (focus, reconnect, team switch).

Fix: drop the team argument so the RPC scope matches the unscoped list. (`src/contexts/NotificationContext.tsx`)

## Test plan
- [ ] Reload the app in dev (StrictMode re-mounts the effect twice). Console should no longer show `Failed to setup real-time subscriptions: Error: cannot add postgres_changes callbacks ...`.
- [ ] Switch teams a few times; only one `user-changes-<id>` channel remains in `notificationService.getActiveChannelNames()`.
- [ ] Click "Mark all as read", then trigger a refetch (switch teams, blur+focus the tab, or wait for the periodic reconnect). Unread count stays at 0.
- [ ] `npx tsc --noEmit` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)