### PR TITLE
fix(auth): add autocomplete attributes and password reveal toggle

### DIFF
--- a/src/locales/en/auth.json
+++ b/src/locales/en/auth.json
@@ -13,6 +13,8 @@
     "passwordPlaceholder": "••••••••",
     "rememberMe": "Remember me",
     "forgotPassword": "Forgot password?",
+    "showPassword": "Show password",
+    "hidePassword": "Hide password",
     "button": "Log in",
     "buttonLoading": "Logging in",
     "withGoogle": "Google",

--- a/src/locales/ms/auth.json
+++ b/src/locales/ms/auth.json
@@ -13,6 +13,8 @@
     "passwordPlaceholder": "••••••••",
     "rememberMe": "Ingat saya",
     "forgotPassword": "Lupa kata laluan?",
+    "showPassword": "Tunjuk kata laluan",
+    "hidePassword": "Sembunyi kata laluan",
     "button": "Log masuk",
     "buttonLoading": "Sedang log masuk",
     "withGoogle": "Google",

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -26,7 +26,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
-import { Loader2, Sun, Moon } from "lucide-react";
+import { Loader2, Sun, Moon, Eye, EyeOff } from "lucide-react";
 
 // Schema factory functions that use translations
 const createLoginSchema = (t: (key: string) => string) => z.object({
@@ -69,6 +69,11 @@ export default function Auth() {
   const [isPasswordResetSent, setIsPasswordResetSent] = useState(false);
   const [isRecoverySession, setIsRecoverySession] = useState(false);
   const [rememberMe, setRememberMe] = useState(false);
+  const [showLoginPassword, setShowLoginPassword] = useState(false);
+  const [showSignupPassword, setShowSignupPassword] = useState(false);
+  const [showSignupConfirmPassword, setShowSignupConfirmPassword] = useState(false);
+  const [showResetPassword, setShowResetPassword] = useState(false);
+  const [showResetConfirmPassword, setShowResetConfirmPassword] = useState(false);
   const { user, signIn, signUp, signInWithGoogle, resetPassword } = useAuth();
   const { t } = useAuthTranslation();
   const { isDarkMode, toggleMode } = useTheme();
@@ -458,7 +463,13 @@ export default function Auth() {
                       <FormItem>
                         <FormLabel>{t("signIn.email")}</FormLabel>
                         <FormControl>
-                          <Input className="h-11" placeholder={t("signIn.emailPlaceholder")} {...field} />
+                          <Input
+                            className="h-11"
+                            type="email"
+                            autoComplete="email"
+                            placeholder={t("signIn.emailPlaceholder")}
+                            {...field}
+                          />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -472,7 +483,30 @@ export default function Auth() {
                       <FormItem>
                         <FormLabel>{t("signIn.password")}</FormLabel>
                         <FormControl>
-                          <Input className="h-11" type="password" placeholder={t("signIn.passwordPlaceholder")} {...field} />
+                          <div className="relative">
+                            <Input
+                              className="h-11 pr-10"
+                              type={showLoginPassword ? "text" : "password"}
+                              autoComplete="current-password"
+                              placeholder={t("signIn.passwordPlaceholder")}
+                              {...field}
+                            />
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              tabIndex={-1}
+                              aria-label={showLoginPassword ? t("signIn.hidePassword") : t("signIn.showPassword")}
+                              className="absolute right-0 top-0 h-full px-3 text-muted-foreground hover:text-foreground hover:bg-transparent"
+                              onClick={() => setShowLoginPassword((prev) => !prev)}
+                            >
+                              {showLoginPassword ? (
+                                <EyeOff className="h-4 w-4" aria-hidden="true" />
+                              ) : (
+                                <Eye className="h-4 w-4" aria-hidden="true" />
+                              )}
+                            </Button>
+                          </div>
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -577,7 +611,13 @@ export default function Auth() {
                       <FormItem>
                         <FormLabel>{t("signUp.email")}</FormLabel>
                         <FormControl>
-                          <Input className="h-11" placeholder={t("signUp.emailPlaceholder")} {...field} />
+                          <Input
+                            className="h-11"
+                            type="email"
+                            autoComplete="email"
+                            placeholder={t("signUp.emailPlaceholder")}
+                            {...field}
+                          />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -591,7 +631,30 @@ export default function Auth() {
                       <FormItem>
                         <FormLabel>{t("signUp.password")}</FormLabel>
                         <FormControl>
-                          <Input className="h-11" type="password" placeholder={t("signUp.passwordPlaceholder")} {...field} />
+                          <div className="relative">
+                            <Input
+                              className="h-11 pr-10"
+                              type={showSignupPassword ? "text" : "password"}
+                              autoComplete="new-password"
+                              placeholder={t("signUp.passwordPlaceholder")}
+                              {...field}
+                            />
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              tabIndex={-1}
+                              aria-label={showSignupPassword ? t("signIn.hidePassword") : t("signIn.showPassword")}
+                              className="absolute right-0 top-0 h-full px-3 text-muted-foreground hover:text-foreground hover:bg-transparent"
+                              onClick={() => setShowSignupPassword((prev) => !prev)}
+                            >
+                              {showSignupPassword ? (
+                                <EyeOff className="h-4 w-4" aria-hidden="true" />
+                              ) : (
+                                <Eye className="h-4 w-4" aria-hidden="true" />
+                              )}
+                            </Button>
+                          </div>
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -605,7 +668,30 @@ export default function Auth() {
                       <FormItem>
                         <FormLabel>{t("signUp.confirmPassword")}</FormLabel>
                         <FormControl>
-                          <Input className="h-11" type="password" placeholder={t("signUp.passwordPlaceholder")} {...field} />
+                          <div className="relative">
+                            <Input
+                              className="h-11 pr-10"
+                              type={showSignupConfirmPassword ? "text" : "password"}
+                              autoComplete="new-password"
+                              placeholder={t("signUp.passwordPlaceholder")}
+                              {...field}
+                            />
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              tabIndex={-1}
+                              aria-label={showSignupConfirmPassword ? t("signIn.hidePassword") : t("signIn.showPassword")}
+                              className="absolute right-0 top-0 h-full px-3 text-muted-foreground hover:text-foreground hover:bg-transparent"
+                              onClick={() => setShowSignupConfirmPassword((prev) => !prev)}
+                            >
+                              {showSignupConfirmPassword ? (
+                                <EyeOff className="h-4 w-4" aria-hidden="true" />
+                              ) : (
+                                <Eye className="h-4 w-4" aria-hidden="true" />
+                              )}
+                            </Button>
+                          </div>
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -699,7 +785,12 @@ export default function Auth() {
                     <FormItem>
                       <FormLabel>{t("forgotPassword.email")}</FormLabel>
                       <FormControl>
-                        <Input placeholder={t("forgotPassword.emailPlaceholder")} {...field} />
+                        <Input
+                          type="email"
+                          autoComplete="email"
+                          placeholder={t("forgotPassword.emailPlaceholder")}
+                          {...field}
+                        />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
@@ -768,7 +859,31 @@ export default function Auth() {
                   <FormItem>
                     <FormLabel>{t("resetPassword.password")}</FormLabel>
                     <FormControl>
-                      <Input type="password" placeholder={t("resetPassword.passwordPlaceholder")} {...field} autoFocus />
+                      <div className="relative">
+                        <Input
+                          className="pr-10"
+                          type={showResetPassword ? "text" : "password"}
+                          autoComplete="new-password"
+                          placeholder={t("resetPassword.passwordPlaceholder")}
+                          {...field}
+                          autoFocus
+                        />
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          tabIndex={-1}
+                          aria-label={showResetPassword ? t("signIn.hidePassword") : t("signIn.showPassword")}
+                          className="absolute right-0 top-0 h-full px-3 text-muted-foreground hover:text-foreground hover:bg-transparent"
+                          onClick={() => setShowResetPassword((prev) => !prev)}
+                        >
+                          {showResetPassword ? (
+                            <EyeOff className="h-4 w-4" aria-hidden="true" />
+                          ) : (
+                            <Eye className="h-4 w-4" aria-hidden="true" />
+                          )}
+                        </Button>
+                      </div>
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -782,7 +897,30 @@ export default function Auth() {
                   <FormItem>
                     <FormLabel>{t("resetPassword.confirmPassword")}</FormLabel>
                     <FormControl>
-                      <Input type="password" placeholder={t("resetPassword.passwordPlaceholder")} {...field} />
+                      <div className="relative">
+                        <Input
+                          className="pr-10"
+                          type={showResetConfirmPassword ? "text" : "password"}
+                          autoComplete="new-password"
+                          placeholder={t("resetPassword.passwordPlaceholder")}
+                          {...field}
+                        />
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          tabIndex={-1}
+                          aria-label={showResetConfirmPassword ? t("signIn.hidePassword") : t("signIn.showPassword")}
+                          className="absolute right-0 top-0 h-full px-3 text-muted-foreground hover:text-foreground hover:bg-transparent"
+                          onClick={() => setShowResetConfirmPassword((prev) => !prev)}
+                        >
+                          {showResetConfirmPassword ? (
+                            <EyeOff className="h-4 w-4" aria-hidden="true" />
+                          ) : (
+                            <Eye className="h-4 w-4" aria-hidden="true" />
+                          )}
+                        </Button>
+                      </div>
                     </FormControl>
                     <FormMessage />
                   </FormItem>


### PR DESCRIPTION
## Summary
- Adds `autoComplete` to every email and password input on the Auth page, resolving the Chrome `[DOM] Input elements should have autocomplete attributes (suggested: "current-password")` console warning.
- Adds a show/hide password toggle (lucide `Eye`/`EyeOff`) to login, signup, signup-confirm, and recovery reset password fields. Icons use `text-muted-foreground hover:text-foreground` so they read clearly in both light and dark mode.
- Adds `signIn.showPassword` / `signIn.hidePassword` strings to `en` and `ms` locales for the toggle's `aria-label`.

## Test plan
- [ ] Run `npm run dev`, open `/auth`, confirm the Chrome DOM autocomplete warning is gone for the login password field.
- [ ] Toggle the eye icon on each password input (login, signup, confirm, recovery) and verify it switches between obscured and plain text.
- [ ] Switch between light and dark mode and verify the eye icon stays visible with adequate contrast in both.
- [ ] Verify keyboard tabbing through the form skips the toggle button (`tabIndex={-1}`).
- [ ] Verify browser password autofill still works (saved credential prompt appears on the login form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added password visibility toggles for all password fields in authentication flows (login, signup, and password recovery).
  * Users can now show or hide password input using dedicated toggle buttons for improved usability.
  * Enhanced localization support with new strings for English and Malay interfaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noa10/mataresit/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->