### PR TITLE
fix(team-invitations): repair team_invitations schema drift + safe redirect

### DIFF
--- a/src/locales/en/auth.json
+++ b/src/locales/en/auth.json
@@ -13,6 +13,8 @@
     "passwordPlaceholder": "••••••••",
     "rememberMe": "Remember me",
     "forgotPassword": "Forgot password?",
+    "showPassword": "Show password",
+    "hidePassword": "Hide password",
     "button": "Log in",
     "buttonLoading": "Logging in",
     "withGoogle": "Google",

--- a/src/locales/ms/auth.json
+++ b/src/locales/ms/auth.json
@@ -13,6 +13,8 @@
     "passwordPlaceholder": "••••••••",
     "rememberMe": "Ingat saya",
     "forgotPassword": "Lupa kata laluan?",
+    "showPassword": "Tunjuk kata laluan",
+    "hidePassword": "Sembunyi kata laluan",
     "button": "Log masuk",
     "buttonLoading": "Sedang log masuk",
     "withGoogle": "Google",

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -26,7 +26,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
-import { Loader2, Sun, Moon } from "lucide-react";
+import { Loader2, Sun, Moon, Eye, EyeOff } from "lucide-react";
 
 // Schema factory functions that use translations
 const createLoginSchema = (t: (key: string) => string) => z.object({
@@ -69,6 +69,11 @@ export default function Auth() {
   const [isPasswordResetSent, setIsPasswordResetSent] = useState(false);
   const [isRecoverySession, setIsRecoverySession] = useState(false);
   const [rememberMe, setRememberMe] = useState(false);
+  const [showLoginPassword, setShowLoginPassword] = useState(false);
+  const [showSignupPassword, setShowSignupPassword] = useState(false);
+  const [showSignupConfirmPassword, setShowSignupConfirmPassword] = useState(false);
+  const [showResetPassword, setShowResetPassword] = useState(false);
+  const [showResetConfirmPassword, setShowResetConfirmPassword] = useState(false);
   const { user, signIn, signUp, signInWithGoogle, resetPassword } = useAuth();
   const { t } = useAuthTranslation();
   const { isDarkMode, toggleMode } = useTheme();
@@ -458,7 +463,13 @@ export default function Auth() {
                       <FormItem>
                         <FormLabel>{t("signIn.email")}</FormLabel>
                         <FormControl>
-                          <Input className="h-11" placeholder={t("signIn.emailPlaceholder")} {...field} />
+                          <Input
+                            className="h-11"
+                            type="email"
+                            autoComplete="email"
+                            placeholder={t("signIn.emailPlaceholder")}
+                            {...field}
+                          />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -472,7 +483,30 @@ export default function Auth() {
                       <FormItem>
                         <FormLabel>{t("signIn.password")}</FormLabel>
                         <FormControl>
-                          <Input className="h-11" type="password" placeholder={t("signIn.passwordPlaceholder")} {...field} />
+                          <div className="relative">
+                            <Input
+                              className="h-11 pr-10"
+                              type={showLoginPassword ? "text" : "password"}
+                              autoComplete="current-password"
+                              placeholder={t("signIn.passwordPlaceholder")}
+                              {...field}
+                            />
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              tabIndex={-1}
+                              aria-label={showLoginPassword ? t("signIn.hidePassword") : t("signIn.showPassword")}
+                              className="absolute right-0 top-0 h-full px-3 text-muted-foreground hover:text-foreground hover:bg-transparent"
+                              onClick={() => setShowLoginPassword((prev) => !prev)}
+                            >
+                              {showLoginPassword ? (
+                                <EyeOff className="h-4 w-4" aria-hidden="true" />
+                              ) : (
+                                <Eye className="h-4 w-4" aria-hidden="true" />
+                              )}
+                            </Button>
+                          </div>
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -577,7 +611,13 @@ export default function Auth() {
                       <FormItem>
                         <FormLabel>{t("signUp.email")}</FormLabel>
                         <FormControl>
-                          <Input className="h-11" placeholder={t("signUp.emailPlaceholder")} {...field} />
+                          <Input
+                            className="h-11"
+                            type="email"
+                            autoComplete="email"
+                            placeholder={t("signUp.emailPlaceholder")}
+                            {...field}
+                          />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -591,7 +631,30 @@ export default function Auth() {
                       <FormItem>
                         <FormLabel>{t("signUp.password")}</FormLabel>
                         <FormControl>
-                          <Input className="h-11" type="password" placeholder={t("signUp.passwordPlaceholder")} {...field} />
+                          <div className="relative">
+                            <Input
+                              className="h-11 pr-10"
+                              type={showSignupPassword ? "text" : "password"}
+                              autoComplete="new-password"
+                              placeholder={t("signUp.passwordPlaceholder")}
+                              {...field}
+                            />
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              tabIndex={-1}
+                              aria-label={showSignupPassword ? t("signIn.hidePassword") : t("signIn.showPassword")}
+                              className="absolute right-0 top-0 h-full px-3 text-muted-foreground hover:text-foreground hover:bg-transparent"
+                              onClick={() => setShowSignupPassword((prev) => !prev)}
+                            >
+                              {showSignupPassword ? (
+                                <EyeOff className="h-4 w-4" aria-hidden="true" />
+                              ) : (
+                                <Eye className="h-4 w-4" aria-hidden="true" />
+                              )}
+                            </Button>
+                          </div>
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -605,7 +668,30 @@ export default function Auth() {
                       <FormItem>
                         <FormLabel>{t("signUp.confirmPassword")}</FormLabel>
                         <FormControl>
-                          <Input className="h-11" type="password" placeholder={t("signUp.passwordPlaceholder")} {...field} />
+                          <div className="relative">
+                            <Input
+                              className="h-11 pr-10"
+                              type={showSignupConfirmPassword ? "text" : "password"}
+                              autoComplete="new-password"
+                              placeholder={t("signUp.passwordPlaceholder")}
+                              {...field}
+                            />
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              tabIndex={-1}
+                              aria-label={showSignupConfirmPassword ? t("signIn.hidePassword") : t("signIn.showPassword")}
+                              className="absolute right-0 top-0 h-full px-3 text-muted-foreground hover:text-foreground hover:bg-transparent"
+                              onClick={() => setShowSignupConfirmPassword((prev) => !prev)}
+                            >
+                              {showSignupConfirmPassword ? (
+                                <EyeOff className="h-4 w-4" aria-hidden="true" />
+                              ) : (
+                                <Eye className="h-4 w-4" aria-hidden="true" />
+                              )}
+                            </Button>
+                          </div>
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -699,7 +785,12 @@ export default function Auth() {
                     <FormItem>
                       <FormLabel>{t("forgotPassword.email")}</FormLabel>
                       <FormControl>
-                        <Input placeholder={t("forgotPassword.emailPlaceholder")} {...field} />
+                        <Input
+                          type="email"
+                          autoComplete="email"
+                          placeholder={t("forgotPassword.emailPlaceholder")}
+                          {...field}
+                        />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
@@ -768,7 +859,31 @@ export default function Auth() {
                   <FormItem>
                     <FormLabel>{t("resetPassword.password")}</FormLabel>
                     <FormControl>
-                      <Input type="password" placeholder={t("resetPassword.passwordPlaceholder")} {...field} autoFocus />
+                      <div className="relative">
+                        <Input
+                          className="pr-10"
+                          type={showResetPassword ? "text" : "password"}
+                          autoComplete="new-password"
+                          placeholder={t("resetPassword.passwordPlaceholder")}
+                          {...field}
+                          autoFocus
+                        />
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          tabIndex={-1}
+                          aria-label={showResetPassword ? t("signIn.hidePassword") : t("signIn.showPassword")}
+                          className="absolute right-0 top-0 h-full px-3 text-muted-foreground hover:text-foreground hover:bg-transparent"
+                          onClick={() => setShowResetPassword((prev) => !prev)}
+                        >
+                          {showResetPassword ? (
+                            <EyeOff className="h-4 w-4" aria-hidden="true" />
+                          ) : (
+                            <Eye className="h-4 w-4" aria-hidden="true" />
+                          )}
+                        </Button>
+                      </div>
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -782,7 +897,30 @@ export default function Auth() {
                   <FormItem>
                     <FormLabel>{t("resetPassword.confirmPassword")}</FormLabel>
                     <FormControl>
-                      <Input type="password" placeholder={t("resetPassword.passwordPlaceholder")} {...field} />
+                      <div className="relative">
+                        <Input
+                          className="pr-10"
+                          type={showResetConfirmPassword ? "text" : "password"}
+                          autoComplete="new-password"
+                          placeholder={t("resetPassword.passwordPlaceholder")}
+                          {...field}
+                        />
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          tabIndex={-1}
+                          aria-label={showResetConfirmPassword ? t("signIn.hidePassword") : t("signIn.showPassword")}
+                          className="absolute right-0 top-0 h-full px-3 text-muted-foreground hover:text-foreground hover:bg-transparent"
+                          onClick={() => setShowResetConfirmPassword((prev) => !prev)}
+                        >
+                          {showResetConfirmPassword ? (
+                            <EyeOff className="h-4 w-4" aria-hidden="true" />
+                          ) : (
+                            <Eye className="h-4 w-4" aria-hidden="true" />
+                          )}
+                        </Button>
+                      </div>
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/supabase/migrations/20260516140000_repair_invitation_acceptance.sql
+++ b/supabase/migrations/20260516140000_repair_invitation_acceptance.sql
@@ -1,0 +1,135 @@
+-- Repair drift from 20250821000000_enhanced_invitation_onboarding_system.
+-- Migration is recorded as applied but the ALTER TABLE team_invitations
+-- block never landed in prod. process_post_auth_invitation writes these
+-- three columns and throws 42703 without them.
+ALTER TABLE public.team_invitations
+  ADD COLUMN IF NOT EXISTS authentication_method VARCHAR(50),
+  ADD COLUMN IF NOT EXISTS acceptance_ip_address INET,
+  ADD COLUMN IF NOT EXISTS acceptance_user_agent TEXT;
+
+-- Patch process_post_auth_invitation: the original function returned
+-- '/teams/' || team_slug as the redirect, but the SPA has no
+-- '/teams/:slug' route — only '/teams' — so accepted invitees hit a
+-- 404 right after joining. Keep all the original behavior; only the
+-- redirect_url branch changes.
+CREATE OR REPLACE FUNCTION public.process_post_auth_invitation(
+  p_invitation_token VARCHAR(255),
+  p_user_id UUID,
+  p_authentication_method VARCHAR(50),
+  p_browser_fingerprint TEXT DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_invitation RECORD;
+  v_existing_member RECORD;
+  v_onboarding_required BOOLEAN := true;
+  v_redirect_url TEXT;
+BEGIN
+  SELECT ti.*, t.name AS team_name, t.slug AS team_slug
+  INTO v_invitation
+  FROM public.team_invitations ti
+  JOIN public.teams t ON t.id = ti.team_id
+  WHERE ti.token = p_invitation_token
+    AND ti.status = 'pending'
+    AND ti.expires_at > NOW();
+
+  IF v_invitation IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Invitation not found or expired',
+      'error_code', 'INVITATION_NOT_FOUND'
+    );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM auth.users
+    WHERE id = p_user_id AND email = v_invitation.email
+  ) THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'User email does not match invitation',
+      'error_code', 'EMAIL_MISMATCH'
+    );
+  END IF;
+
+  SELECT * INTO v_existing_member
+  FROM public.team_members
+  WHERE team_id = v_invitation.team_id AND user_id = p_user_id;
+
+  IF v_existing_member IS NULL THEN
+    INSERT INTO public.team_members (
+      team_id, user_id, role, permissions, invitation_accepted_at, added_by
+    ) VALUES (
+      v_invitation.team_id, p_user_id, v_invitation.role,
+      v_invitation.permissions, NOW(), v_invitation.invited_by
+    );
+  ELSE
+    v_onboarding_required := false;
+  END IF;
+
+  UPDATE public.team_invitations
+  SET
+    status = 'accepted',
+    accepted_at = NOW(),
+    authentication_method = p_authentication_method,
+    acceptance_ip_address = (
+      SELECT ip_address FROM public.invitation_states
+      WHERE invitation_token = p_invitation_token
+    ),
+    acceptance_user_agent = (
+      SELECT user_agent FROM public.invitation_states
+      WHERE invitation_token = p_invitation_token
+    )
+  WHERE id = v_invitation.id;
+
+  UPDATE public.invitation_states
+  SET
+    state = 'accepted',
+    user_id = p_user_id,
+    authentication_method = p_authentication_method,
+    authenticated_at = NOW()
+  WHERE invitation_token = p_invitation_token;
+
+  SELECT redirect_after_auth INTO v_redirect_url
+  FROM public.invitation_states
+  WHERE invitation_token = p_invitation_token;
+
+  INSERT INTO public.team_audit_logs (
+    team_id, action, action_description, performed_by, target_user_id,
+    metadata, ip_address, user_agent
+  ) VALUES (
+    v_invitation.team_id,
+    'invitation_accepted',
+    'Team invitation accepted via ' || p_authentication_method,
+    p_user_id, p_user_id,
+    jsonb_build_object(
+      'invitation_id', v_invitation.id,
+      'authentication_method', p_authentication_method,
+      'browser_fingerprint', p_browser_fingerprint,
+      'was_existing_member', v_existing_member IS NOT NULL
+    ),
+    (SELECT ip_address FROM public.invitation_states WHERE invitation_token = p_invitation_token),
+    (SELECT user_agent FROM public.invitation_states WHERE invitation_token = p_invitation_token)
+  );
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'result', jsonb_build_object(
+      'invitation_accepted', true,
+      'team_id', v_invitation.team_id,
+      'team_name', v_invitation.team_name,
+      'user_role', v_invitation.role,
+      'onboarding_required', v_onboarding_required,
+      -- Land on /teams (which exists) instead of /teams/{slug} (which doesn't).
+      -- Caller can switch into the freshly-joined team from the workspace switcher.
+      'redirect_url', COALESCE(v_redirect_url, '/teams')
+    )
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.process_post_auth_invitation TO authenticated;
+GRANT EXECUTE ON FUNCTION public.process_post_auth_invitation TO service_role;


### PR DESCRIPTION
## Summary
Two more issues blocking invite acceptance after PR #78. Migration applied to prod via MCP; this PR commits the file so future environments stay in sync.

1. \`process_post_auth_invitation\` threw 42703: \`column "authentication_method" of relation "team_invitations" does not exist\`. Migration \`20250821000000\` is recorded as applied but its \`ALTER TABLE team_invitations\` block never landed in prod. Same drift pattern as the previous fix. Re-add \`authentication_method\`, \`acceptance_ip_address\`, \`acceptance_user_agent\` idempotently.
2. The function returned \`redirect_url = '/teams/' || team_slug\`, but the SPA only registers \`/teams\` (no \`/teams/:slug\`) — accepted invitees hit a 404 right after joining (\`404 Error: User attempted to access non-existent route: /teams/65c7…\`). Fallback now lands on \`/teams\`, which exists.

## Test plan
- [x] Migration applied to prod, verified the three columns now exist on \`team_invitations\`.
- [ ] Existing-user magic link → land on \`/invite/{token}\` → accept → land on \`/teams\` (not 404).
- [ ] Browser console shows no more \`authentication_method\` 42703.
- [ ] Fresh-email signup → email-confirm → \`/invite/{token}\` → accept → \`/teams\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added password visibility toggle for all password fields on login, signup, and password reset pages
  * Expanded localization support for password visibility controls in English and Malay

* **Bug Fixes**
  * Corrected team invitation acceptance workflow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noa10/mataresit/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->