### PR TITLE
perf(team-invitations): skip api.ipify.org lookup that blocks validation

### DIFF
--- a/src/pages/TeamInvitation.tsx
+++ b/src/pages/TeamInvitation.tsx
@@ -60,14 +60,13 @@ export default function TeamInvitationPage() {
 
       // Generate browser fingerprint and get client info
       const browserFingerprint = invitationFlowService.generateBrowserFingerprint();
-      const ipAddress = await invitationFlowService.getClientIPAddress();
       const userAgent = navigator.userAgent;
 
       // Detect user state and validate invitation
       const result = await invitationFlowService.detectUserState(
         token,
         browserFingerprint,
-        ipAddress,
+        null,
         userAgent
       );
 

--- a/src/services/invitationFlowService.ts
+++ b/src/services/invitationFlowService.ts
@@ -350,17 +350,14 @@ export class InvitationFlowService {
   }
 
   /**
-   * Get client IP address (best effort)
+   * Client-side IP lookup is disabled — we previously called api.ipify.org but
+   * it blocks invitation validation for tens of seconds when the request is
+   * blocked by an adblocker, network policy, or simply slow. The server-side
+   * RPC reads the IP from request headers in `acceptance_ip_address` for
+   * audit logging, so the browser doesn't need to provide one.
    */
   async getClientIPAddress(): Promise<string | null> {
-    try {
-      const response = await fetch('https://api.ipify.org?format=json');
-      const data = await response.json();
-      return data.ip;
-    } catch (error) {
-      console.warn('Could not determine client IP address:', error);
-      return null;
-    }
+    return null;
   }
 
   /**


### PR DESCRIPTION
## Summary
Invitation validation was taking minutes before the user could accept. \`getClientIPAddress()\` calls \`https://api.ipify.org?format=json\` with no timeout, and \`TeamInvitation.detectUserStateAndLoadInvitation\` awaits it **before** running user-state detection. When the request is blocked (adblocker, network policy, Incognito with stricter rules) the page sits on the browser's default TCP timeout — tens of seconds to a few minutes.

The IP is only used for audit logging (\`team_invitations.acceptance_ip_address\`); the server-side RPC can read it from request headers. The browser doesn't need to provide one.

This PR stubs \`getClientIPAddress()\` to return \`null\` and stops awaiting it on the detection path.

## Test plan
- [ ] Open \`/invite/{token}\` in Incognito with an adblocker active. Page should resolve in under a second.
- [ ] No \`api.ipify.org\` requests in the Network tab.
- [ ] No \`Could not determine client IP address\` warning in console.
- [ ] Acceptance still succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)