### PR TITLE
fix(team-invitations): add missing audit-action enum values + Button import

### DIFF
--- a/src/pages/TeamInvitation.tsx
+++ b/src/pages/TeamInvitation.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useTeam } from '@/contexts/TeamContext';
 import { invitationFlowService, UserStateDetectionResult } from '@/services/invitationFlowService';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import { Spinner } from '@/components/ui/spinner';
 import { useToast } from '@/hooks/use-toast';
 import {

--- a/supabase/migrations/20260517100000_repair_team_audit_action_values.sql
+++ b/supabase/migrations/20260517100000_repair_team_audit_action_values.sql
@@ -1,0 +1,25 @@
+-- Fill in team_audit_action enum values that were never added.
+-- The base enum was created by 20250722000001 with 18 values, but later
+-- migrations (20250722010000 user removal system, 20250722040000+ bulk
+-- ops, 20250822000000 invitation flow) reference additional labels that
+-- were skipped along with those migrations' other objects.
+--
+-- Symptom: detect_user_invitation_state throws 22P02
+--   "invalid input value for enum team_audit_action: 'invitation_accessed'"
+-- because it logs an audit row when an invite link is opened.
+--
+-- ALTER TYPE ADD VALUE IF NOT EXISTS is idempotent and re-runnable.
+ALTER TYPE public.team_audit_action ADD VALUE IF NOT EXISTS 'invitation_accessed';
+ALTER TYPE public.team_audit_action ADD VALUE IF NOT EXISTS 'bulk_invitation';
+ALTER TYPE public.team_audit_action ADD VALUE IF NOT EXISTS 'bulk_member_removal';
+ALTER TYPE public.team_audit_action ADD VALUE IF NOT EXISTS 'bulk_operation_cancelled';
+ALTER TYPE public.team_audit_action ADD VALUE IF NOT EXISTS 'bulk_operation_retried';
+ALTER TYPE public.team_audit_action ADD VALUE IF NOT EXISTS 'bulk_permission_updated';
+ALTER TYPE public.team_audit_action ADD VALUE IF NOT EXISTS 'bulk_role_update';
+ALTER TYPE public.team_audit_action ADD VALUE IF NOT EXISTS 'member_removal_cancelled';
+ALTER TYPE public.team_audit_action ADD VALUE IF NOT EXISTS 'member_removal_scheduled';
+ALTER TYPE public.team_audit_action ADD VALUE IF NOT EXISTS 'member_role_updated';
+ALTER TYPE public.team_audit_action ADD VALUE IF NOT EXISTS 'member_sessions_invalidated';
+ALTER TYPE public.team_audit_action ADD VALUE IF NOT EXISTS 'operation_cancelled';
+ALTER TYPE public.team_audit_action ADD VALUE IF NOT EXISTS 'operation_rescheduled';
+ALTER TYPE public.team_audit_action ADD VALUE IF NOT EXISTS 'operation_scheduled';


### PR DESCRIPTION
## Summary
Two issues still blocking invite acceptance after PR #82:

1. \`detect_user_invitation_state\` throws \`22P02: invalid input value for enum team_audit_action: 'invitation_accessed'\`. The base enum was created by \`20250722000001\` with 18 values, but later migrations (user removal, bulk ops, invitation flow) reference **14 additional labels** that were skipped along with those migrations' other objects. Add all 14 missing values idempotently (\`ADD VALUE IF NOT EXISTS\`).
2. \`TeamInvitation.tsx\` renders \`<Button>\` in its error fallback (lines 162, 165) but never imports it. When the RPC throws, the error UI tries to render and \`ReferenceError\` crashes the entire React tree — that's why you saw a blank page with no red toast. Add the missing import.

## Test plan
- [x] Migration applied to prod via MCP, verified all 14 values now exist.
- [ ] Open \`/invite/{token}\` — page renders normally.
- [ ] Acceptance flow completes end-to-end, lands on \`/teams\`.
- [ ] If the RPC ever errors again, the fallback UI renders instead of going blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)