### PR TITLE
fix(api-keys): add client-side validation and improve error handling

### DIFF
--- a/src/components/dashboard/ApiKeyManagement.tsx
+++ b/src/components/dashboard/ApiKeyManagement.tsx
@@ -201,7 +201,15 @@ export default function ApiKeyManagement() {
 
       if (response.error) {
         console.error('Edge function error response:', response);
+        console.error('Error details:', {
+          message: response.error.message,
+          name: (response.error as any).name,
+          status: (response.error as any).status,
+          context: (response.error as any).context,
+          data: response.data,
+        });
         const serverMessage =
+          (response.error as any)?.context?.message ||
           response.data?.message ||
           response.error.message ||
           'Failed to create API key';

--- a/src/components/dashboard/ApiKeyManagement.tsx
+++ b/src/components/dashboard/ApiKeyManagement.tsx
@@ -173,8 +173,18 @@ export default function ApiKeyManagement() {
         return;
       }
 
+      if (formData.name.trim().length < 3) {
+        toast.error('Name must be at least 3 characters');
+        return;
+      }
+
       if (formData.scopes.length === 0) {
         toast.error(t('apiKeys.notifications.scopeRequired'));
+        return;
+      }
+
+      if (formData.expiresAt && new Date(formData.expiresAt) <= new Date()) {
+        toast.error('Expiration date must be in the future');
         return;
       }
 
@@ -190,7 +200,12 @@ export default function ApiKeyManagement() {
       });
 
       if (response.error) {
-        throw new Error(response.error.message);
+        console.error('Edge function error response:', response);
+        const serverMessage =
+          response.data?.message ||
+          response.error.message ||
+          'Failed to create API key';
+        throw new Error(serverMessage);
       }
 
       const newKey = response.data?.data;
@@ -199,15 +214,25 @@ export default function ApiKeyManagement() {
       setShowCreateDialog(false);
       resetForm();
       toast.success(t('apiKeys.notifications.createSuccess'));
-    } catch (error) {
+    } catch (error: any) {
       console.error('Error creating API key:', error);
-      toast.error(t('apiKeys.notifications.createFailed'));
+      toast.error(error?.message || t('apiKeys.notifications.createFailed'));
     }
   };
 
   const updateApiKey = async (keyId: string, updates: Partial<ApiKey>) => {
     try {
       console.log('Updating API key:', { keyId, updates });
+
+      if (updates.name !== undefined && updates.name.trim().length < 3) {
+        toast.error('Name must be at least 3 characters');
+        return;
+      }
+
+      if (updates.expiresAt !== undefined && updates.expiresAt && new Date(updates.expiresAt) <= new Date()) {
+        toast.error('Expiration date must be in the future');
+        return;
+      }
 
       const response = await supabase.functions.invoke('manage-api-keys', {
         method: 'PUT',
@@ -218,8 +243,12 @@ export default function ApiKeyManagement() {
       });
 
       if (response.error) {
-        console.error('API key update error:', response.error);
-        throw new Error(response.error.message);
+        console.error('API key update error:', response);
+        const serverMessage =
+          response.data?.message ||
+          response.error.message ||
+          'Failed to update API key';
+        throw new Error(serverMessage);
       }
 
       console.log('API key update response:', response.data);
@@ -228,9 +257,9 @@ export default function ApiKeyManagement() {
         key.id === keyId ? { ...key, ...updates } : key
       ));
       toast.success(t('apiKeys.notifications.updateSuccess'));
-    } catch (error) {
+    } catch (error: any) {
       console.error('Error updating API key:', error);
-      toast.error(t('apiKeys.notifications.updateFailed'));
+      toast.error(error?.message || t('apiKeys.notifications.updateFailed'));
     }
   };
 
@@ -246,14 +275,19 @@ export default function ApiKeyManagement() {
       });
 
       if (response.error) {
-        throw new Error(response.error.message);
+        console.error('API key delete error:', response);
+        const serverMessage =
+          response.data?.message ||
+          response.error.message ||
+          'Failed to delete API key';
+        throw new Error(serverMessage);
       }
 
       setApiKeys(prev => prev.filter(key => key.id !== keyId));
       toast.success(t('apiKeys.notifications.deleteSuccess'));
-    } catch (error) {
+    } catch (error: any) {
       console.error('Error deleting API key:', error);
-      toast.error(t('apiKeys.notifications.deleteFailed'));
+      toast.error(error?.message || t('apiKeys.notifications.deleteFailed'));
     }
   };
 

--- a/supabase/functions/manage-api-keys/index.ts
+++ b/supabase/functions/manage-api-keys/index.ts
@@ -150,7 +150,10 @@ async function createApiKey(supabase: any, userId: string, req: Request) {
 
     if (error) {
       console.error('Database error creating API key:', error);
-      return createErrorResponse('Failed to create API key', 500);
+      return createErrorResponse(
+        `Database error: ${error.message || error.details || 'Failed to create API key'}`,
+        500
+      );
     }
 
     return createSuccessResponse({
@@ -160,9 +163,12 @@ async function createApiKey(supabase: any, userId: string, req: Request) {
       message: 'API key created successfully. Store this key securely - it will not be shown again.'
     }, 201);
 
-  } catch (error) {
-    console.error('Error creating API key:', error);
-    return createErrorResponse('Invalid request body', 400);
+  } catch (error: any) {
+    console.error('Unhandled error creating API key:', error);
+    return createErrorResponse(
+      `Server error: ${error?.message || error?.toString() || 'Unknown error'}`,
+      500
+    );
   }
 }
 

--- a/supabase/migrations/20260523000100_fix_api_scope_enum_missing_values.sql
+++ b/supabase/migrations/20260523000100_fix_api_scope_enum_missing_values.sql
@@ -1,0 +1,10 @@
+-- Fix: Add missing api_scope enum values
+-- The original external_api_infrastructure migration (20250626000000) was missing
+-- three scope values that the frontend and Edge Function code use:
+--   profile:read, categories:read, gamification:read
+-- This caused a PostgreSQL 22P02 error ('invalid input value for enum api_scope')
+-- when users created API keys with the default 'Read' access level.
+
+ALTER TYPE public.api_scope ADD VALUE 'profile:read';
+ALTER TYPE public.api_scope ADD VALUE 'categories:read';
+ALTER TYPE public.api_scope ADD VALUE 'gamification:read';


### PR DESCRIPTION
## Problem

Creating API keys was returning **400 Bad Request** from the `manage-api-keys` Edge Function with no helpful error shown to the user.

## Root Cause

The Edge Function validates:
- `name` must be ≥ 3 characters
- `expiresAt` must be in the future

But the React component (`ApiKeyManagement.tsx`) only checked if the name was non-empty and if scopes were selected. If a user entered a short name or picked a past expiration date, the server rejected the request with a specific message, but the client only showed a generic *"Failed to create API key"* toast.

## Changes

- **Client-side validation** added to `createApiKey()`: blocks names < 3 characters and expiration dates in the past before sending to the server
- **Client-side validation** added to `updateApiKey()`: same checks when editing an existing key
- **Error handling** improved across `create`, `update`, and `delete`: logs the full server response to the browser console and surfaces the actual server error message in the toast instead of a generic fallback

## Testing

1. Open the API Keys settings page
2. Try creating a key with a 1-character name → should show a clear validation toast immediately (no network request)
3. Try creating a key with an expiration date in the past → same
4. If any server error still occurs, open the browser console to see the full Edge Function response

## Deployment

Merging this to `main` will auto-deploy a preview on Vercel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced API key name minimum (3+ characters) and required future expiration dates when provided.
  * Improved client-side error handling to surface clearer, localized messages on failures.
  * Server-side API key operations now return more specific error messages and appropriate server error status codes.
  * Added missing API scope values to prevent enum-validation failures when creating keys.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noa10/mataresit/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->