### PR TITLE
Potential fix for code scanning alert no. 11114: Unused variable, import, function or class

### DIFF
--- a/src/components/team/enhanced/CollaborationMetricsChart.tsx
+++ b/src/components/team/enhanced/CollaborationMetricsChart.tsx
@@ -28,11 +28,8 @@ import {
 import { 
   MessageSquare, 
   Users, 
-  Share2,
-  Clock,
   TrendingUp,
   Network,
-  Activity,
   Target,
   Zap
 } from 'lucide-react';


### PR DESCRIPTION
Potential fix for [https://github.com/noa10/mataresit/security/code-scanning/11114](https://github.com/noa10/mataresit/security/code-scanning/11114)

Remove the unused icon imports `Activity`, `Clock`, and `Share2` from the `lucide-react` import list in `src/components/team/enhanced/CollaborationMetricsChart.tsx`.

Best single fix without changing behavior:
- Edit only the import block at lines 28–38.
- Keep all currently used imports unchanged.
- Delete just `Share2`, `Clock`, and `Activity` entries from that destructured import list.
- No functional code changes are needed; this is a cleanup-only fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
